### PR TITLE
Add `serve_on_port`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,4 +32,4 @@ mod server;
 
 pub use templates::HTML;
 pub use panel::Panel;
-pub use server::{ServerConfig, serve, serve_with_config};
+pub use server::{ServerConfig, serve, serve_on_port, serve_with_config};

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,6 +42,21 @@ pub fn serve<P, F>(f: F) -> Result<()>
     serve_with_config::<P, _>(Default::default(), f)
 }
 
+/// Serve a panel on a specific port.
+///
+/// `f` is the callback for panel updates.
+pub fn serve_on_port<P, F>(port: u16, f: F) -> Result<()>
+    where P: Panel,
+          F: Fn(P) + Sync + Send + 'static,
+{
+    let config = ServerConfig{
+        verbose: true,
+        listen_on: format!("127.0.0.1:{}", port)
+    };
+
+    serve_with_config::<P, _>(config, f)
+}
+
 /// Serve a panel and configure the server.
 ///
 /// `f` is the callback for panel updates.


### PR DESCRIPTION
This should remove a lot of boilerplate when you just want to host the panel on a different port. This should fix #5.